### PR TITLE
build command for windows

### DIFF
--- a/CoffeeScript.sublime-build
+++ b/CoffeeScript.sublime-build
@@ -3,4 +3,8 @@
 ,	"path": "/usr/local/bin:$PATH"
 ,	"selector": "source.coffee"
 ,	"working_dir": "$project_path"
+,	"windows": {
+		"path": "$PATH"
+,		"shell": true
+	}
 }


### PR DESCRIPTION
I bet you haven't tested it for windows. `path` directive is obviously wrong and I have problem running something without `shell: true`.
