### PR TITLE
Bug fix in .tmLanguage

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -261,7 +261,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([a-zA-Z\$_](\w|\$|\.)*\s*(?!\::)((:)|(=))(?!(\s*\(.*\))?\s*((=|-)&gt;)))</string>
+			<string>([a-zA-Z\$_](\w|\$|\.)*\s*(?!\::)((:)|(=[^=]))(?!(\s*\(.*\))?\s*((=|-)&gt;)))</string>
 			<key>name</key>
 			<string>variable.assignment.coffee</string>
 		</dict>


### PR DESCRIPTION
Fixed issue where a conditional like:

```
if ( derp == herp )
```

would highlight "derp" as a variable and mark "==" as variable.assignment.coffee
