### PR TITLE
Add cson as a matching file type

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -217,7 +217,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>/(?![\s=/*+{}?]).*?[^\\]/[igmy]{0,4}(?![a-zA-Z0-9])</string>
+			<string>\\.</string>
 			<key>name</key>
 			<string>string.regexp.coffee</string>
 		</dict>


### PR DESCRIPTION
I added cson (coffeescript flavour of json) to the list of matched file types. This is the only changed needed to make sublime highlight cson-code properly.
