### PR TITLE
"Run" build variant

### DIFF
--- a/CoffeeScript.sublime-build
+++ b/CoffeeScript.sublime-build
@@ -3,4 +3,11 @@
 ,	"path": "/usr/local/bin:$PATH"
 ,	"selector": "source.coffee"
 ,	"working_dir": "$project_path"
+,	"variants":
+	[
+		{
+			"name": "Run",
+			"cmd": ["coffee", "$file"]
+		}
+	]
 }


### PR DESCRIPTION
This adds a "Run" build variant to run and display the output of the current CoffeeScript file directly.
