### PR TITLE
Fix to compile with multibyte characters

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -11,7 +11,7 @@ def run(cmd, args = [], source="", cwd = None, env = None):
 		args = [args]
 	if sys.platform == "win32":
 		proc = Popen([cmd]+args, env=env, cwd=cwd, stdout=PIPE, stdin=PIPE, stderr=PIPE, shell=True)
-		stat = proc.communicate(input=source)
+		stat = proc.communicate(input=source.encode('utf-8'))
 	else:
 		if env is None:
 			env = {"PATH": settings.get('binDir', '/usr/local/bin')}
@@ -22,7 +22,7 @@ def run(cmd, args = [], source="", cwd = None, env = None):
 		proc = Popen(command, env=env, cwd=cwd, stdout=PIPE, stderr=PIPE)
 		stat = proc.communicate()
 	okay = proc.returncode == 0
-	return {"okay": okay, "out": stat[0], "err": stat[1]}
+	return {"okay": okay, "out": stat[0].decode('utf-8'), "err": stat[1]}
 
 def brew(args, source):
 	if sys.platform == "win32":


### PR DESCRIPTION
If a source file contains multibyte characters (Japanese characters),
Check Syntax or Display JavaScript fails with UnicodeEncodeError on
Windows. Adding encode/decode with utf-8 works without errors.

I got the following error messages with multibyte characters source file.

```
Traceback (most recent call last):
  File ".\sublime_plugin.py", line 356, in run_
  File ".\CoffeeScript.py", line 90, in run
  File ".\CoffeeScript.py", line 32, in brew
  File ".\CoffeeScript.py", line 14, in run
  File ".\subprocess.py", line 701, in communicate
  File ".\subprocess.py", line 911, in _communicate
UnicodeEncodeError: 'ascii' codec can't encode characters in position 21-23: ordinal not in range(128)
```
