### PR TITLE
new snippet for logging object with description

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ You can access the commands either using the command palette (`ctrl+shift+P` or 
 
 **Classes**
 
-	Class - cla
+	Class: cla
+
+**Logging**
+    
+    Log statement:          log
+    Log object/description: logo
 
 **Other**
 

--- a/Snippets/Console Log Object.tmSnippet
+++ b/Snippets/Console Log Object.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>console.log "${0:object}: #{${0:object}}"</string>
+	<key>name</key>
+	<string>logo</string>
+	<key>scope</key>
+	<string>source.coffee</string>
+	<key>tabTrigger</key>
+	<string>logo</string>
+	<key>uuid</key>
+	<string>FBC44B18-323A-4C00-A35B-15E41830C5AD</string>
+</dict>
+</plist>


### PR DESCRIPTION
I find explicit logging to be exceptionally useful for debugging coffeescript, so i added one more snippet for logging. You'll have description and object dump in one keyboard stroke.
logo<tab> -> console.log "object: #{object}"

I have updated README.MD accordingly and fixed one typo("-" instead of ":").

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/xavura/coffeescript-sublime-plugin/39)

<!-- Reviewable:end -->
