### PR TITLE
Fixing the syntax highlighter for some special cases

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -355,7 +355,7 @@
             <key>name</key>
             <string>meta.function.symbols.coffee</string>
             <key>begin</key>
-            <string>^\s*(describe|it|app\.(get|post|put|all|del|delete))</string>
+            <string>^\s*(describe|it|app\.(get|post|put|all|del|delete))[^\w]</string>
             <key>end</key>
             <string>$</string>
             <key>patterns</key>


### PR DESCRIPTION
For example, if you have a variable named "items", the old regex would highlight "it" in the word "items". I've added a small change to not highlight if the next character is a word character.
